### PR TITLE
feat: setup github actions ci

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Setup Docker Build
+        run: |
+          docker build -t ci-base -f infra-data-lake/ci/Dockerfile .
+      
+      - name: Build Docker images and deploy
+        run: |
+          make build
+          make deploy

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: localhost
 
 on:
   push:
@@ -13,14 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out code
+      - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Setup Docker Build
+      - name: Build and deploy (localhost)
         run: |
-          docker build -t ci-base -f infra-data-lake/ci/Dockerfile .
-      
-      - name: Build Docker images and deploy
-        run: |
-          make build
-          make deploy
+          make deploy DOCKER_COMPOSE_ARGS=-d
+          make healthcheck ENV=localhost

--- a/Justfile
+++ b/Justfile
@@ -19,15 +19,16 @@ build:
     ./infra-scripts/build_spark_docker.sh
     ./infra-scripts/build_notebook_docker.sh
 
-# confirms you have a working environment
-helloworld:
-    cd svc-hello-world && sbt run 
+# perform a health check for services at an environment
+healthcheck env:
+	./infra-scripts/health_check.sh {{env}}
 
-deploy:
+# deploys to a local environment, passes arguments to docker-compose
+deploy args:
     docker rm -f $(docker ps -a -q) || true
     just build
     mkdir -p notebook-data-lake/src
     mkdir -p notebook-data-lake/data
     chmod -R 777 ./notebook-data-lake/src
     chmod -R 777 ./notebook-data-lake/data
-    cd infra-data-lake/localhost && docker-compose up
+    cd infra-data-lake/localhost && docker-compose up {{args}}

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 # Lists available commands
 help:
 	@echo "Available commands:"
-	@echo "help             - Shows available commands"
-	@echo "build            - Initializes environment (downloads dependencies via mvn, builds Spark and notebook Docker images)"
-	@echo "onboard          - Automated onbaording workflow to check installed dependencies"
-	@echo "clean-deploy     - Deploys locally"
-	@echo "deploy           - Deletes all user containers then deploys locally"
-
+	@echo "help                         - Shows available commands"
+	@echo "build                        - Initializes environment (downloads dependencies via mvn, builds Spark and notebook Docker images)"
+	@echo "onboard                      - Automated onbaording workflow to check installed dependencies"
+	@echo "clean-deploy                 - Deletes all user containers then deploys locally"
+	@echo "deploy DOCKER_COMPOSE_ARGS   - Deploys locally. Supports COMPOSE_ARGS=<foo> for trailing arguments"
+	@echo "healthcheck ENV              - Do a health check across all services deployed by the docker-compose for an environment"
 # Onboarding workflow
 onboard:
 	./infra-scripts/onboarding.sh
@@ -17,13 +17,17 @@ build:
 	./infra-scripts/build_spark_docker.sh
 	./infra-scripts/build_notebook_docker.sh
 
+# Deploy workflow
 deploy:
 	make build
 	mkdir -p notebook-data-lake/src
 	mkdir -p notebook-data-lake/data
 	chmod -R 777 ./notebook-data-lake/src
 	chmod -R 777 ./notebook-data-lake/data
-	cd infra-data-lake/localhost && docker-compose up
+	cd infra-data-lake/localhost && docker-compose up $(DOCKER_COMPOSE_ARGS)
+
+healthcheck:
+	./infra-scripts/health_check.sh ${ENV}
 
 clean-deploy:
 	docker rm -f $$(docker ps -a -q) || true
@@ -32,4 +36,4 @@ clean-deploy:
 	mkdir -p notebook-data-lake/data
 	chmod -R 777 ./notebook-data-lake/src
 	chmod -R 777 ./notebook-data-lake/data
-	cd infra-data-lake/localhost && docker-compose up
+	cd infra-data-lake/localhost && docker-compose up $(DOCKER_COMPOSE_ARGS)

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Effortlessly dive in and unleash your data's potential, today!
 ## Features
 
 - **Mock Blob Storage**: Mimics Blob Storage locally, enabling seamless integration with notebooks.
-- **Spark Cluster**: Configured with Docker containers for distributed computing tasks and large-scale dataset processing. Dependencies are managed via the `infra-data-lake` pom file and pulled onto the repository via `mvn`-based bash scripts e.g. `get_spark_deps`.
+- **Spark Cluster**: Configured with Docker containers for distributed computing tasks and large-scale dataset processing. Dependencies are managed via the `infra-data-lake` pom file and pulled onto the repository via `mvn`-based bash `get_spark_deps.sh`.
 - **PySpark Notebooks**: Jupyter notebooks for interactive data exploration and analysis.
+- **CI/CD Heath Checks:** Implemented using bash, GitHub Actions, and Docker Compose, CI health checks ensure services are built, up, and healthy before merging to a protected main.
 
 ## Getting Started
 

--- a/infra-data-lake/ci/Dockerfile
+++ b/infra-data-lake/ci/Dockerfile
@@ -1,17 +1,34 @@
 FROM adoptopenjdk/openjdk11:alpine
 
+# Install Maven
 ENV MAVEN_VERSION=3.8.3
 ENV MAVEN_HOME=/opt/maven
 ENV PATH=${MAVEN_HOME}/bin:${PATH}
-RUN wget -qO- "https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | tar -xz -C /opt/ \
-    && ln -s /opt/apache-maven-${MAVEN_VERSION} ${MAVEN_HOME}
 
+# Download Maven
+RUN wget -qO /opt/maven.tar.gz "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
+
+# Extract Maven
+RUN tar -xzf /opt/maven.tar.gz -C /opt/
+
+# Remove Maven archive
+RUN rm /opt/maven.tar.gz
+
+# Create symbolic link
+RUN ln -s /opt/apache-maven-${MAVEN_VERSION} ${MAVEN_HOME}
+
+# Install Scala
 ENV SCALA_VERSION=2.12.15
 ENV SCALA_HOME=/usr/local/scala
 ENV PATH=${SCALA_HOME}/bin:${PATH}
-RUN wget -qO- "https://downloads.lightbend.com/scala/${SCALA_VERSION}/scala-${SCALA_VERSION}.tgz" | tar -xz -C /usr/local/ \
-    && ln -s /usr/local/scala-${SCALA_VERSION} ${SCALA_HOME}
 
+# Download Scala
+RUN wget -qO- "https://downloads.lightbend.com/scala/${SCALA_VERSION}/scala-${SCALA_VERSION}.tgz" | tar -xz -C /usr/local/
+
+# Create symbolic link for Scala
+RUN ln -s /usr/local/scala-${SCALA_VERSION} ${SCALA_HOME}
+
+# Install other dependencies
 RUN apk --no-cache add curl
 
 CMD ["bash"]

--- a/infra-data-lake/ci/Dockerfile
+++ b/infra-data-lake/ci/Dockerfile
@@ -1,0 +1,17 @@
+FROM adoptopenjdk/openjdk11:alpine
+
+ENV MAVEN_VERSION=3.8.3
+ENV MAVEN_HOME=/opt/maven
+ENV PATH=${MAVEN_HOME}/bin:${PATH}
+RUN wget -qO- "https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | tar -xz -C /opt/ \
+    && ln -s /opt/apache-maven-${MAVEN_VERSION} ${MAVEN_HOME}
+
+ENV SCALA_VERSION=2.12.15
+ENV SCALA_HOME=/usr/local/scala
+ENV PATH=${SCALA_HOME}/bin:${PATH}
+RUN wget -qO- "https://downloads.lightbend.com/scala/${SCALA_VERSION}/scala-${SCALA_VERSION}.tgz" | tar -xz -C /usr/local/ \
+    && ln -s /usr/local/scala-${SCALA_VERSION} ${SCALA_HOME}
+
+RUN apk --no-cache add curl
+
+CMD ["bash"]

--- a/infra-data-lake/localhost/docker-compose.yml
+++ b/infra-data-lake/localhost/docker-compose.yml
@@ -15,24 +15,13 @@ services:
     volumes:
       - ./../../notebook-data-lake/data:/data
       - ./../../notebook-data-lake/src:/src
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "7077"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   spark-worker-1:
-    image: orgname/data_lake_spark:latest
-    environment:
-      - SPARK_MODE=worker
-      - SPARK_MASTER_URL=spark://spark:7077
-      - SPARK_WORKER_MEMORY=1G
-      - SPARK_WORKER_CORES=1
-      - SPARK_RPC_AUTHENTICATION_ENABLED=no
-      - SPARK_RPC_ENCRYPTION_ENABLED=false
-      - SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED=no
-      - SPARK_SSL_ENABLED=no
-      - SPARK_NO_DAEMONIZE=true
-    volumes:
-      - ./../../notebook-data-lake/data:/data
-      - ./../../notebook-data-lake/src:/src
-
-  spark-worker-2:
     image: orgname/data_lake_spark:latest
     environment:
       - SPARK_MODE=worker
@@ -63,4 +52,9 @@ services:
       - ./../../infra-mock-blob-storage:/home/jovyan/mock-blob-storage
       - ./../../notebook-data-lake/notebooks:/home/jovyan/notebooks
       - ./../../notebook-data-lake/data:/home/jovyan/data
-      - ./../../notebook-data-lake/src:/home/jovyan/src 
+      - ./../../notebook-data-lake/src:/home/jovyan/src
+    healthcheck:
+      test: ["CMD-SHELL", "curl --silent --fail http://localhost:8888/lab/api || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5

--- a/infra-scripts/health_check.sh
+++ b/infra-scripts/health_check.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+ENV=$1
+
+if [ -z "$ENV" ]; then
+    echo "Usage: $0 <environment>"
+    exit 1
+fi
+
+# navigate to the appropriate directory
+cd "infra-data-lake/$ENV" || { echo "Directory 'infra-data-lake/$ENV' not found"; exit 1; }
+
+# check if docker-compose.yml exists in the directory
+if [ ! -f "docker-compose.yml" ]; then
+    echo "docker-compose.yml not found in directory 'infra-data-lake/$ENV'"
+    exit 1
+fi
+
+# show docker-compose services status
+docker-compose ps -a
+
+# healthcheck loop
+timeout=0
+until docker-compose ps -q | xargs docker inspect --format='{{.State.Health.Status}}' | grep -v "healthy"; do
+    echo "Waiting for services to become healthy..."
+    sleep 5
+    timeout=$((timeout+5))
+    if [ $timeout -ge 30 ]; then
+        echo "Timeout reached. Services are still not healthy."
+        exit 1
+    fi
+done


### PR DESCRIPTION
**Objective**

This PR sets up Github Actions to automatically validate whether the build and deploy is successful and passes healthchecks. The health checks are added by creating healthcheck sidecars on the Docker run level which then provide status reports to a bash script acting implementing a listener w/ a back-off algorithm. 

The error state of the bash script, or any error leading up to that, causes the workflow to fail. We ensure that we test to make sure the healthchecks are passed within a reasonable window. 

We need a back-off because sometimes it can take Spark's workers a little bit of time to register with the head node, which results in temporary flakyness. We will then turn off all main push permissions with bad builds to prevent flaky deployments.

**Testing**

Health check fail status was tested against Github E2E.